### PR TITLE
Add mobile stylesheet for better mobile visibility

### DIFF
--- a/assets/mobile.css
+++ b/assets/mobile.css
@@ -1,0 +1,17 @@
+/* Mobile-specific overrides */
+body {
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.grid {
+  grid-template-columns: 1fr !important;
+}
+
+.controls {
+  flex-direction: column !important;
+}
+
+.card {
+  width: 100%;
+}

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./assets/style.css" />
+  <link rel="stylesheet" href="./assets/mobile.css" media="(max-width: 768px)" />
 
   <!-- 공용: 카드 완전 숨김 유틸 -->
   <style>

--- a/macro/index.html
+++ b/macro/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../assets/style.css" />
+  <link rel="stylesheet" href="../assets/mobile.css" media="(max-width: 768px)" />
 
   <!-- 카드 숨김용 간단 스타일(완전 제거) -->
   <style>

--- a/macro/malthus/index.html
+++ b/macro/malthus/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <link rel="stylesheet" href="../../assets/mobile.css" media="(max-width: 768px)" />
 
   <!-- favicon 404 방지 -->
   <link rel="icon" href="data:," />

--- a/metrics/index.html
+++ b/metrics/index.html
@@ -10,6 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
 
   <link rel="stylesheet" href="../assets/style.css" />
+  <link rel="stylesheet" href="../assets/mobile.css" media="(max-width: 768px)" />
 
   <!-- 카드 숨김용 간단 스타일(완전 제거) -->
   <style>

--- a/metrics/normal-distribution/index.html
+++ b/metrics/normal-distribution/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <link rel="stylesheet" href="../../assets/mobile.css" media="(max-width: 768px)" />
 
   <!-- Chart.js -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>

--- a/metrics/ols/index.html
+++ b/metrics/ols/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <link rel="stylesheet" href="../../assets/mobile.css" media="(max-width: 768px)" />
 
   <!-- 차트(CDN, 버전 고정) -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>

--- a/metrics/t-distribution/index.html
+++ b/metrics/t-distribution/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <link rel="stylesheet" href="../../assets/mobile.css" media="(max-width: 768px)" />
 
   <!-- Chart.js -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>

--- a/micro/cobb–douglas/icc/index.html
+++ b/micro/cobb–douglas/icc/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../assets/style.css" />
+  <link rel="stylesheet" href="../../../assets/mobile.css" media="(max-width: 768px)" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
   <style>
     main.grid { grid-template-columns: minmax(300px,440px) 1fr; }

--- a/micro/cobb–douglas/index.html
+++ b/micro/cobb–douglas/index.html
@@ -12,6 +12,7 @@
 
   <!-- 공통 리소스: 상대경로 필수 -->
   <link rel="stylesheet" href="../../assets/style.css" />
+  <link rel="stylesheet" href="../../assets/mobile.css" media="(max-width: 768px)" />
 
   <!-- 카드 숨김/수식용 간단 스타일 -->
   <style>

--- a/micro/cobb–douglas/pcc/index.html
+++ b/micro/cobb–douglas/pcc/index.html
@@ -11,6 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../assets/style.css" />
+  <link rel="stylesheet" href="../../../assets/mobile.css" media="(max-width: 768px)" />
 
   <!-- 차트(CDN, 버전 고정) -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>

--- a/micro/cobb–douglas/point/index.html
+++ b/micro/cobb–douglas/point/index.html
@@ -11,6 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../assets/style.css" />
+  <link rel="stylesheet" href="../../../assets/mobile.css" media="(max-width: 768px)" />
 
   <!-- 차트(CDN, 버전 고정) -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>

--- a/micro/index.html
+++ b/micro/index.html
@@ -12,6 +12,7 @@
 
   <!-- 공통 리소스: 상대경로 -->
   <link rel="stylesheet" href="../assets/style.css" />
+  <link rel="stylesheet" href="../assets/mobile.css" media="(max-width: 768px)" />
 
   <!-- 카드 숨김용 간단 스타일(완전 제거) -->
   <style>
@@ -29,8 +30,7 @@
     <a class="card" href="./linear-supply-demand-curve/" data-section="linear" aria-label="선형 수요·공급 곡선으로 이동">
       <div class="emoji" aria-hidden="true">📈</div>
       <h2>선형 수요·공급 곡선</h2>
-      <p>Q = -aP + b, Q = cP + d에서 균형점git add -A
-과 잉여 계산</p>
+      <p>Q = -aP + b, Q = cP + d에서 균형점과 잉여 계산</p>
     </a>
 
     <!-- Cobb–Douglas로 이동하는 카드 -->

--- a/micro/leon/index.html
+++ b/micro/leon/index.html
@@ -11,6 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <link rel="stylesheet" href="../../assets/mobile.css" media="(max-width: 768px)" />
 
   <!-- 차트 (버전 고정) -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>

--- a/micro/linear-supply-demand-curve/index.html
+++ b/micro/linear-supply-demand-curve/index.html
@@ -11,6 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <link rel="stylesheet" href="../../assets/mobile.css" media="(max-width: 768px)" />
 
   <!-- Chart.js -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>


### PR DESCRIPTION
## Summary
- Add new `mobile.css` with single-column and control layout tweaks for small screens
- Link mobile stylesheet from every HTML page for improved mobile readability
- Remove stray text from micro index description

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b164eb8710832991d147e9bb142061