### PR TITLE
fix: remove stray text from micro card

### DIFF
--- a/micro/index.html
+++ b/micro/index.html
@@ -29,8 +29,7 @@
     <a class="card" href="./linear-supply-demand-curve/" data-section="linear" aria-label="선형 수요·공급 곡선으로 이동">
       <div class="emoji" aria-hidden="true">📈</div>
       <h2>선형 수요·공급 곡선</h2>
-      <p>Q = -aP + b, Q = cP + d에서 균형점git add -A
-과 잉여 계산</p>
+      <p>Q = -aP + b, Q = cP + d에서 균형점과 잉여 계산</p>
     </a>
 
     <!-- Cobb–Douglas로 이동하는 카드 -->


### PR DESCRIPTION
## Summary
- fix microeconomics card description by removing stray `git add -A`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9836fe0f48329a7899762ed1b38ff