### PR TITLE
Update input prompts and remove obsolete notes

### DIFF
--- a/micro/cobb–douglas/icc/index.html
+++ b/micro/cobb–douglas/icc/index.html
@@ -67,7 +67,7 @@
   <main class="grid">
     <!-- (1) 시작: 파라미터 먼저 입력 -->
     <section class="card controls" id="init-card" aria-labelledby="init-title">
-      <h2 id="init-title">파라미터 입력 후 그리기</h2>
+      <h2 id="init-title">값 입력</h2>
       <div class="row">
         <label for="i-alpha">α (x의 지수)</label>
         <input id="i-alpha" type="number" step="0.01" value="0.50" inputmode="decimal">
@@ -93,7 +93,6 @@
         <input id="i-Mmax" type="number" step="1" inputmode="numeric" placeholder="자동">
       </div>
       <button id="drawBtn" style="margin-top:.5rem;">그리기</button>
-      <p class="muted" style="margin-top:6px;">※ 그리기 후, 파라미터 주변으로 슬라이더가 생성되고 M(소득)을 0↔M<sub>max</sub>로 왕복시켜 ICC를 확인할 수 있어요.</p>
     </section>
 
     <!-- (2) 컨트롤 -->
@@ -154,8 +153,8 @@
       </details>
 
       <dl class="nums" aria-live="polite" style="margin-top:.5rem;">
-        <dt>x* (최적)</dt><dd id="xStar">–</dd>
-        <dt>y* (최적)</dt><dd id="yStar">–</dd>
+        <dt>x*</dt><dd id="xStar">–</dd>
+        <dt>y*</dt><dd id="yStar">–</dd>
         <dt>x절편 (M/p<sub>x</sub>)</dt><dd id="xInt">–</dd>
         <dt>y절편 (M/p<sub>y</sub>)</dt><dd id="yInt">–</dd>
       </dl>

--- a/micro/cobb–douglas/pcc/index.html
+++ b/micro/cobb–douglas/pcc/index.html
@@ -74,7 +74,7 @@
   <main class="grid">
     <!-- (1) 시작: 파라미터 먼저 입력 -->
     <section class="card controls" id="init-card" aria-labelledby="init-title">
-      <h2 id="init-title">파라미터 입력 후 그리기</h2>
+      <h2 id="init-title">값 입력</h2>
       <div class="row">
         <label for="i-alpha">α (x의 지수)</label>
         <input id="i-alpha" type="number" step="0.01" value="0.50" inputmode="decimal">
@@ -111,7 +111,6 @@
         <input id="i-Pmax" type="number" step="0.05" inputmode="decimal" placeholder="자동">
       </div>
       <button id="drawBtn" type="button" style="margin-top:.5rem;">그리기</button>
-      <p class="muted" style="margin-top:6px;">※ 그리기 후, 파라미터 주변으로 슬라이더가 생성되고 선택한 가격 P를 P<sub>min</sub>↔P<sub>max</sub>로 왕복시켜 PCC를 확인할 수 있어요.</p>
     </section>
 
     <!-- (2) 컨트롤 -->

--- a/micro/cobb–douglas/point/index.html
+++ b/micro/cobb–douglas/point/index.html
@@ -70,7 +70,7 @@
   <main class="grid">
     <!-- (1) 시작 화면: 초기값 먼저 받기 (분수/표현식 입력 지원) -->
     <section class="card controls" id="init-card" aria-labelledby="init-title">
-      <h2 id="init-title">초기값 입력 후 그리기 (분수/표현식 가능)</h2>
+      <h2 id="init-title">값 입력(분수 가능)</h2>
       <div class="row">
         <label for="i-alpha">α (x의 지수)</label>
         <input id="i-alpha" type="text" inputmode="text" value="1/2" placeholder="예: 1/2, 0.5">
@@ -92,7 +92,6 @@
         <input id="i-M" type="text" inputmode="text" value="60" placeholder="예: 60, 120/2">
       </div>
       <button id="drawBtn" style="margin-top:.5rem;">그리기</button>
-      <p class="muted" style="margin-top:6px;">※ 그리기 후에 각 값 주변 범위로 슬라이더가 자동 생성됩니다. 분수/표현식 입력 가능.</p>
       <p class="muted" id="initStatus" aria-live="polite"></p>
     </section>
 
@@ -171,12 +170,12 @@
         <dt>y절편 (M/p<sub>y</sub>)</dt><dd id="yInt">–</dd>
       </dl>
       <p id="statusMsg" class="muted" aria-live="polite"></p>
-      <p class="muted">내부해(α,β&gt;0): <em>x*=(α/(α+β))·M/p<sub>x</sub>,&nbsp; y*=(β/(α+β))·M/p<sub>y</sub></em></p>
+
     </section>
 
     <!-- (3) 차트 카드: 초기 그리기 이후에만 표시 -->
     <section class="card" id="chart-card" hidden aria-labelledby="chart-title">
-      <h2 id="chart-title">예산선 · 무차별곡선(U*) · 최적점</h2>
+      <h2 id="chart-title">예산선 · 무차별곡선 · 최적점</h2>
 
       <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:8px;">
         <div class="legend" aria-hidden="true">

--- a/micro/leon/index.html
+++ b/micro/leon/index.html
@@ -81,7 +81,7 @@
   <main class="grid">
     <!-- (1) 시작 화면 -->
     <section class="card controls" id="init-card" aria-labelledby="init-title">
-      <h2 id="init-title">초기값 입력 후 그리기 (분수/표현식 가능)</h2>
+      <h2 id="init-title">값 입력(분수 표현 가능)</h2>
 
       <!-- α,β 수식형 입력 -->
       <div class="formula" aria-label="효용함수와 α,β 입력">
@@ -91,7 +91,7 @@
         <span class="frac">y / <input id="i-beta" class="frac-input" type="text" inputmode="text" value="1" aria-label="β (y 쪽)" placeholder="예: 1, 1/3"></span>
         <span>)</span>
       </div>
-      <p class="formula-note">※ α,β는 <kbd>min(x/α , y/β)</kbd>의 분모에 직접 입력합니다.</p>
+      <p class="formula-note">※ α,β는 <kbd>min(x/α , y/β)</kbd>의 분모에 직접 입력.</p>
 
       <div class="row">
         <label for="i-px">가격 p<sub>x</sub></label>
@@ -107,7 +107,6 @@
       </div>
 
       <button id="drawBtn" style="margin-top:.5rem;">그리기</button>
-      <p class="muted" style="margin-top:6px;">※ 그리기 후 α,β·가격은 슬라이더로 미세 조정, M은 재입력으로만 변경(ICC는 선만 표시).</p>
       <p class="muted" id="initStatus" aria-live="polite"></p>
     </section>
 

--- a/micro/linear-supply-demand-curve/index.html
+++ b/micro/linear-supply-demand-curve/index.html
@@ -78,7 +78,7 @@
   <main class="grid">
     <!-- 컨트롤 -->
     <section class="card controls" aria-labelledby="ctl-title">
-      <h2 id="ctl-title">식으로 입력 (분수/표현식 가능)</h2>
+      <h2 id="ctl-title">값 입력(분수 가능)</h2>
 
       <div class="eq" aria-label="수요곡선 식 입력">
         <strong>수요</strong>


### PR DESCRIPTION
## Summary
- Revise instructional text to use concise "값 입력" phrasing across micro tools
- Remove outdated guidance and internal solution notes from Cobb–Douglas pages
- Clarify Leontief setup instructions and clean up extra note

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9861112908329b9bf9c8c9c9a9450