### PR TITLE
Remove footer copyright from chi-squared metric page

### DIFF
--- a/metrics/chi-squared/index.html
+++ b/metrics/chi-squared/index.html
@@ -107,7 +107,6 @@
   <footer class="site-footer">
     <a class="card" href="../" style="display:inline-block;padding:12px 18px;">← 이전으로</a>
     <a class="card" href="../../" style="display:inline-block;padding:12px 18px;">← 처음으로</a>
-    <small>© <span id="year"></span> aries0401-svc</small>
   </footer>
 
   <!-- 공통 스크립트 -->


### PR DESCRIPTION
## Summary
- remove hard-coded copyright from chi-squared metric page

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68baa757e0dc8329a896170739621a9a