### PR TITLE
Remove copyright footer from non-home pages

### DIFF
--- a/macro/malthus/index.html
+++ b/macro/malthus/index.html
@@ -167,7 +167,6 @@
   <footer class="site-footer">
     <a class="card" href="../" style="display:inline-block;padding:12px 18px;">← 이전으로</a>
     <a class="card" href="../../" style="display:inline-block;padding:12px 18px;">← 처음으로</a>
-    <div style="margin-top:10px;"><small>© <span id="year"></span> aries0401-svc</small></div>
   </footer>
 
   <!-- 공통 스크립트(키보드 인터랙션 등). 별 애니메이션은 #starfield가 없어서 실행 안 됨 -->

--- a/metrics/chi-squared/index.html
+++ b/metrics/chi-squared/index.html
@@ -107,7 +107,6 @@
   <footer class="site-footer">
     <a class="card" href="../" style="display:inline-block;padding:12px 18px;">← 이전으로</a>
     <a class="card" href="../../" style="display:inline-block;padding:12px 18px;">← 처음으로</a>
-    <small>© <span id="year"></span> aries0401-svc</small>
   </footer>
 
   <!-- 공통 스크립트 -->

--- a/metrics/clt/index.html
+++ b/metrics/clt/index.html
@@ -140,7 +140,6 @@
   <footer class="site-footer">
     <a class="card" href="../" style="display:inline-block;padding:12px 18px;">← 이전으로</a>
     <a class="card" href="../../" style="display:inline-block;padding:12px 18px;">← 처음으로</a>
-    <div style="margin-top:10px;"><small>© <span id="year"></span> aries0401-svc</small></div>
   </footer>
 
   <!-- 공통 스크립트(키보드 인터랙션/연도 표기) -->

--- a/micro/cobb–douglas/icc/index.html
+++ b/micro/cobb–douglas/icc/index.html
@@ -179,7 +179,6 @@
   <footer class="site-footer">
     <a class="card" href="../" style="display:inline-block;padding:12px 18px;">← 이전으로</a>
     <a class="card" href="../../../" style="display:inline-block;padding:12px 18px;">← 처음으로</a>
-    <small>© <span id="year"></span> aries0401-svc</small>
   </footer>
 
   <script src="../../../assets/site.js"></script>

--- a/micro/cobb–douglas/index.html
+++ b/micro/cobb–douglas/index.html
@@ -85,7 +85,6 @@
   <footer class="site-footer">
     <a class="card" href="../" style="display:inline-block;padding:12px 18px;">← 이전으로</a>
     <a class="card" href="../../" style="display:inline-block;padding:12px 18px;">← 처음으로</a>
-    <small>© <span id="year"></span> aries0401-svc</small>
   </footer>
 
   <!-- ✅ 하위 주제 가시성 토글: true면 보임, false면 숨김 -->

--- a/micro/cobb–douglas/pcc/index.html
+++ b/micro/cobb–douglas/pcc/index.html
@@ -217,7 +217,6 @@
   <footer class="site-footer">
     <a class="card" href="../" style="display:inline-block;padding:12px 18px;">← 이전으로</a>
     <a class="card" href="../../../" style="display:inline-block;padding:12px 18px;">← 처음으로</a>
-    <small>© <span id="year"></span> aries0401-svc</small>
   </footer>
 
   <!-- 공통 스크립트 -->

--- a/micro/cobb–douglas/point/index.html
+++ b/micro/cobb–douglas/point/index.html
@@ -195,7 +195,6 @@
   <footer class="site-footer">
     <a class="card" href="../" style="display:inline-block;padding:12px 18px;">← 이전으로</a>
     <a class="card" href="../../../" style="display:inline-block;padding:12px 18px;">← 처음으로</a>
-    <small>© <span id="year"></span> aries0401-svc</small>
   </footer>
 
   <!-- 공통 스크립트 -->

--- a/micro/leon/index.html
+++ b/micro/leon/index.html
@@ -196,7 +196,6 @@
   <footer class="site-footer">
     <a class="card" href="../" style="display:inline-block;padding:12px 18px;">← 이전으로</a>
     <a class="card" href="../../" style="display:inline-block;padding:12px 18px;">← 처음으로</a>
-    <small>© <span id="year"></span> aries0401-svc</small>
   </footer>
 
   <!-- 공통 스크립트 -->

--- a/micro/linear-supply-demand-curve/index.html
+++ b/micro/linear-supply-demand-curve/index.html
@@ -165,7 +165,6 @@
   <footer class="site-footer">
     <a class="card" href="../" style="display:inline-block;padding:12px 18px;">← 이전으로</a>
     <a class="card" href="../../" style="display:inline-block;padding:12px 18px;">← 처음으로</a>
-    <small>© <span id="year"></span> aries0401-svc</small>
   </footer>
 
   <!-- 공통 스크립트 -->


### PR DESCRIPTION
## Summary
- remove hard-coded copyright from macro and metrics pages
- strip footer copyright from microeconomics visualizations

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68baa757e0dc8329a896170739621a9a