### PR TITLE
Add shared GA4 loader for all pages

### DIFF
--- a/assets/ga4.js
+++ b/assets/ga4.js
@@ -1,0 +1,16 @@
+(function (window, document) {
+  var MEASUREMENT_ID = 'G-JYZ7KL1YXZ';
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = window.gtag || function () {
+    window.dataLayer.push(arguments);
+  };
+
+  var script = document.createElement('script');
+  script.async = true;
+  script.src = 'https://www.googletagmanager.com/gtag/js?id=' + MEASUREMENT_ID;
+  document.head.appendChild(script);
+
+  window.gtag('js', new Date());
+  window.gtag('config', MEASUREMENT_ID, { transport_type: 'beacon' });
+})(window, document);

--- a/index.html
+++ b/index.html
@@ -6,14 +6,7 @@
   <title>양재_archive | Micro · Macro · Metrics</title>
   <meta name="description" content="미시경제학, 거시경제학, 계량경제학 중에서 선택하세요." />
 
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JYZ7KL1YXZ"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-JYZ7KL1YXZ', { transport_type: 'beacon' });
-  </script>
+  <script src="./assets/ga4.js" defer></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/macro/index.html
+++ b/macro/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../assets/style.css" />
+  <script src="../assets/ga4.js" defer></script>
 
   <!-- 카드 숨김용 간단 스타일(완전 제거) -->
   <style>

--- a/macro/islm/index.html
+++ b/macro/islm/index.html
@@ -12,6 +12,7 @@
 
   <!-- 공통 리소스: 상대경로 필수 -->
   <link rel="stylesheet" href="../../assets/style.css" />
+  <script src="../../assets/ga4.js" defer></script>
 
   <!-- 카드 숨김/수식용 간단 스타일 -->
   <style>

--- a/macro/islm/islm_gen/index.html
+++ b/macro/islm/islm_gen/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../assets/style.css">
+  <script src="../../../assets/ga4.js" defer></script>
   <link rel="icon" href="data:,">
 
   <style>

--- a/macro/malthus/index.html
+++ b/macro/malthus/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <script src="../../assets/ga4.js" defer></script>
 
   <!-- favicon 404 방지 -->
   <link rel="icon" href="data:," />

--- a/metrics/chi-squared/index.html
+++ b/metrics/chi-squared/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <script src="../../assets/ga4.js" defer></script>
 
   <style>
     /* 레이아웃: 컨트롤은 전체폭, 그래프 2열(모바일 1열) */

--- a/metrics/clt/index.html
+++ b/metrics/clt/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <script src="../../assets/ga4.js" defer></script>
 
   <!-- favicon 404 방지 -->
   <link rel="icon" href="data:," />

--- a/metrics/index.html
+++ b/metrics/index.html
@@ -12,6 +12,7 @@
 
   <!-- 공통 리소스: 상대경로 -->
   <link rel="stylesheet" href="../assets/style.css" />
+  <script src="../assets/ga4.js" defer></script>
 
   <!-- 카드 숨김용 간단 스타일(완전 제거) -->
   <style>

--- a/metrics/normal-distribution/index.html
+++ b/metrics/normal-distribution/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <script src="../../assets/ga4.js" defer></script>
 
   <!-- Chart.js -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>

--- a/metrics/ols/index.html
+++ b/metrics/ols/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <script src="../../assets/ga4.js" defer></script>
 
   <!-- 차트(CDN, 버전 고정) -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>

--- a/metrics/t-distribution/index.html
+++ b/metrics/t-distribution/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <script src="../../assets/ga4.js" defer></script>
 
   <!-- Chart.js -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>

--- a/micro/cobb–douglas/icc/index.html
+++ b/micro/cobb–douglas/icc/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../assets/style.css" />
+  <script src="../../../assets/ga4.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
   <style>
     main.grid { grid-template-columns: minmax(300px,440px) 1fr; }

--- a/micro/cobb–douglas/index.html
+++ b/micro/cobb–douglas/index.html
@@ -12,6 +12,7 @@
 
   <!-- 공통 리소스: 상대경로 필수 -->
   <link rel="stylesheet" href="../../assets/style.css" />
+  <script src="../../assets/ga4.js" defer></script>
 
   <!-- 카드 숨김/수식용 간단 스타일 -->
   <style>

--- a/micro/cobb–douglas/pcc/index.html
+++ b/micro/cobb–douglas/pcc/index.html
@@ -11,6 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../assets/style.css" />
+  <script src="../../../assets/ga4.js" defer></script>
 
   <!-- 차트(CDN, 버전 고정) -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>

--- a/micro/cobb–douglas/point/index.html
+++ b/micro/cobb–douglas/point/index.html
@@ -11,6 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../../assets/style.css" />
+  <script src="../../../assets/ga4.js" defer></script>
 
   <!-- 차트(CDN, 버전 고정) -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>

--- a/micro/index.html
+++ b/micro/index.html
@@ -12,6 +12,7 @@
 
   <!-- 공통 리소스: 상대경로 -->
   <link rel="stylesheet" href="../assets/style.css" />
+  <script src="../assets/ga4.js" defer></script>
 
   <!-- 카드 숨김용 간단 스타일(완전 제거) -->
   <style>

--- a/micro/leon/index.html
+++ b/micro/leon/index.html
@@ -11,6 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <script src="../../assets/ga4.js" defer></script>
 
   <!-- 차트 (버전 고정) -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>

--- a/micro/linear-supply-demand-curve/index.html
+++ b/micro/linear-supply-demand-curve/index.html
@@ -11,6 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/style.css" />
+  <script src="../../assets/ga4.js" defer></script>
 
   <!-- Chart.js -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>


### PR DESCRIPTION
## Summary
- add a shared `assets/ga4.js` that injects the GA4 tag with measurement ID G-JYZ7KL1YXZ
- load the shared analytics script from every HTML page so the inline GA4 snippets are no longer duplicated

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d64460436483299652d17911e44813